### PR TITLE
Removed premature clearance of password for AD

### DIFF
--- a/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/DirectEvidenceVerifier.java
+++ b/auth/realm/ldap/src/main/java/org/wildfly/security/auth/realm/ldap/DirectEvidenceVerifier.java
@@ -102,8 +102,6 @@ class DirectEvidenceVerifier implements EvidenceVerifier {
                         log.debugf(e, "Credential direct evidence verification failed. DN: [%s]", distinguishedName);
                     } catch (NamingException | URISyntaxException e) {
                         throw log.directLdapVerificationFailed(distinguishedName, url, e);
-                    } finally {
-                        ((PasswordGuessEvidence) evidence).destroy();
                     }
                 }
 


### PR DESCRIPTION
In case you have an M$ AD as LDAP-Server and configured it as elytron realm, you have to use the `DirectEvidenceVerifier`.

Once you have users coming from this Realm, no "HTTP-Remoting" calls are possible, 'cuz the password is set to `0x00` within the verifying process. So when the system tries to connect to a second system using the stored credentials, it fails.

We tracked down the problem only for AD-User. A parallel JDBC-Realm can do the remote calls without problems. Through debugging we found out, that the `DirectEvidenceVerifier` clears (set to series of `0x00`) too early (premature), so the caller stores the wrong credentials (`0x00`) in heap for later remote calls after verifying it.